### PR TITLE
Minor improvements

### DIFF
--- a/MonitorControl/Base.lproj/MainMenu.xib
+++ b/MonitorControl/Base.lproj/MainMenu.xib
@@ -13,7 +13,6 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="MonitorControl" customModuleProvider="target">
             <connections>
-                <outlet property="quitClicked" destination="JTa-2I-AsI" id="pCf-S9-cfs"/>
                 <outlet property="statusMenu" destination="lCi-vw-mwp" id="iBf-iw-RcA"/>
             </connections>
         </customObject>


### PR DESCRIPTION
This patch series brings two improvements:

 * It removes an outdated outlet from the interface.
 * It reverts d46622913069aec69470d37e3c5de7188690aea0 which bumped `ddcctl`. That change introduced kfix/ddcctl@3ba7c0f which raises a DDC delay from 10 nanoseconds to 30 milliseconds (!) which apparently works on some displays but freezes others.